### PR TITLE
Feature/insert item at array index

### DIFF
--- a/data/raw-model/install-postgresql-anyarray_splice-sql-format.js
+++ b/data/raw-model/install-postgresql-anyarray_splice-sql-format.js
@@ -1,6 +1,6 @@
 exports.format = (schema) => {
 
-    return `DROP FUNCTION IF EXISTS "${schema}".anyarray_splice(anyarray, integer, anyarray);
+    return `DROP FUNCTION IF EXISTS "${schema}".anyarray_splice(input_array anyarray, start_index integer, delete_count integer, insert_items anyarray);
     CREATE OR REPLACE FUNCTION "${schema}".anyarray_splice(input_array anyarray, start_index integer, delete_count integer, insert_items anyarray)
         RETURNS anyarray AS
     $BODY$

--- a/data/service/postgre-s-q-l-service.js
+++ b/data/service/postgre-s-q-l-service.js
@@ -59,6 +59,8 @@ var RawDataService = require("mod/data/service/raw-data-service").RawDataService
     ReadOnlyPostgreSQLClientPool,
     ProcessEnv = process.env;
 
+let RAW_MODEL_PATH = "../raw-model/";
+
 
 
 // assume a role using the sourceCreds
@@ -1137,6 +1139,27 @@ PostgreSQLService.addClassProperties({
         }
     },
 
+    _functionRegExp: {
+        value: /function\s*([\w\d\_\.]*)\(/
+    },
+    /**
+     * Returns the function name extracted from the passed SQL statement screen
+     *
+     *  ... schema.function_name ...
+     * 
+     * @private
+     * @argument {DataStream} dataStream
+     */
+    _functionNameFromSQLStatement: {
+        value: function(rawDataOperation, error) {
+            let schemaPrefix = `"${rawDataOperation.schema}"."`,
+                match = this._functionRegExp.exec(error.message),
+                functionName = match && match[1];
+
+            return functionName && functionName.replace(schemaPrefix, "");
+        }
+    },
+
     _objectDescriptorNameForRawDataOperationErrorExecutingDataOperation: {
         value: function(rawDataOperation, error, dataOperation) {
             let message = error.message,
@@ -1311,8 +1334,13 @@ PostgreSQLService.addClassProperties({
                 error.propertyDescriptor = propertyDescriptor;
 
                 console.error("mapRawDataOperationErrorToDataOperation rawDataOperation: ", rawDataOperation, objectDescriptor.name+": propertyDescriptor: ", propertyDescriptor.name);
-            } 
-            else if(doesNotExist && isDatabaseError) { //code == '3D000'
+            } else if (error.code === "42883" && doesNotExist) {
+                error.name = DataOperationErrorNames.FunctionMissing;
+                error.cause = {
+                    sql: rawDataOperation.sql,
+                    functionName: this._functionNameFromSQLStatement(rawDataOperation, error)
+                };
+            } else if(doesNotExist && isDatabaseError) { //code == '3D000'
                 error.name = DataOperationErrorNames.DatabaseMissing;
             }
             return error;
@@ -4182,7 +4210,7 @@ PostgreSQLService.addClassProperties({
                     require.async("../raw-model/install-postGIS-sql-format"),
                     require.async("../raw-model/install-postgresql-anyarray_remove-sql-format"),
                     require.async("../raw-model/install-postgresql-anyarray_concat_uniq-sql-format"),
-                    require.async("../raw-model/install-postgresql-anyarray_splice_uniq-sql-format"),
+                    require.async("../raw-model/install-postgresql-anyarray_splice-sql-format"),
                     require.async("../raw-model/install-postgresql-intervalrange-sql-format"),
                     require.async("../raw-model/create-postgresql-map-entry-type-sql-format")
                 ])
@@ -4220,6 +4248,34 @@ PostgreSQLService.addClassProperties({
 
             return createSchemaPromise;
 
+        }
+    },
+
+    _installDatabaseFunctionWithNameInSchema: {
+        value: function (functionName, schemaName) {
+            functionName = functionName.replace(schemaName + ".", "");
+            let pathToFunctionDefinition = `${RAW_MODEL_PATH}install-postgresql-${functionName}-sql-format`,
+                self = this;
+            return require.async(pathToFunctionDefinition).then((fnDefinition) => {
+                let sql = fnDefinition.format(schemaName),
+                    rawDataOperation = {};
+
+                this.mapConnectionToRawDataOperation(rawDataOperation);
+                rawDataOperation.sql = sql;
+
+                return new Promise(function(resolve, reject) {
+                    self.performRawDataOperation(rawDataOperation, function (err, data) {
+                        if (err) {
+                            // an error occurred
+                            console.error("createFunction() performRawDataOperation Error", err, err.stack, rawDataOperation);
+                            reject(err);
+                        }
+                        else {
+                            resolve(true);
+                        }
+                    });
+                });
+            });
         }
     },
 
@@ -4985,9 +5041,8 @@ PostgreSQLService.addClassProperties({
                 recordKeys = Object.keys(dataChanges),
                 setRecordKeys = Array(recordKeys.length),
                 // sqlColumns = recordKeys.join(","),
-                i, countI, iKey, iKeyEscaped, iValue, iMappedValue, iAssignment, iRawType, iPropertyDescriptor, iPrimaryKey,
-                iHasAddedValue, iHasRemovedValues, iPrimaryKeyValue,
-                iKeyValue,
+                i, countI, iKey, iKeyEscaped, iValue, iMappedValue, iAssignment, iRawType, iPropertyDescriptor, 
+                iHasAddedValues, iHasRemovedValues, iHasIndex,
                 dataSnapshot = updateOperation.snapshot,
                 dataSnapshotKeys = dataSnapshot ? Object.keys(dataSnapshot) : null,
                 condition,
@@ -6361,7 +6416,26 @@ PostgreSQLService.addClassProperties({
         
                             });
         
-                    } else if(error.name === DataOperationErrorNames.TransactionDeadlock) {
+                    } else if (error.name === DataOperationErrorNames.FunctionMissing) {
+                        let functionName = error.cause && error.cause.functionName;
+                        return this._installDatabaseFunctionWithNameInSchema(functionName, rawTransaction.schema).then(() => {
+                            this._tryPerformRawTransactionForDataOperationWithClient(rawTransaction, transactionOperation, client, done, responseOperation);
+                        }).catch((error) => {
+                            shouldRetry = false;
+                            console.error('_tryPerformRawTransactionForDataOperationWithClient() Error adding function with name: ', functionName);
+        
+                                //Repeat block from bellow, neeed to have something like responseOperationForReadOperation() to do it once there
+                            responseOperation.type = transactionOperation.type ===  DataOperation.Type.CommitTransactionOperation 
+                            ? DataOperation.Type.CommitTransactionFailedOperation 
+                            : DataOperation.Type.PerformTransactionFailedOperation
+                            responseOperation.data = error;
+    
+                            // release the client back to the pool
+                            done();
+    
+                            responseOperation.target.dispatchEvent(responseOperation);
+                        })
+                    } else if (error.name === DataOperationErrorNames.TransactionDeadlock) {
                         shouldRetry = false;
                         this._tryPerformRawTransactionForDataOperationWithClient(rawTransaction, transactionOperation, client, done, responseOperation);
     


### PR DESCRIPTION
The purpose of this change is to support add/remove/replace at index for arrays stored in a DB column. 

The changes assume that there is one update operation per array change on the client. A future iteration needs to support the possibility of multiple changes on the same array in a single update operation.
